### PR TITLE
fix(contact): corriger le chevauchement des inputs dans le formulaire

### DIFF
--- a/themes/laubardemont/layouts/partials/contact-form.html
+++ b/themes/laubardemont/layouts/partials/contact-form.html
@@ -24,7 +24,7 @@
       
       {{/* Nom & Prénom */}}
       <div class="grid gap-6 md:grid-cols-2">
-        <div>
+        <div class="min-w-0">
           <label for="First_Name" class="mb-2 block text-sm font-medium text-stone-700">
             Prénom
           </label>
@@ -38,7 +38,7 @@
           >
         </div>
 
-        <div>
+        <div class="min-w-0">
           <label for="Last_Name" class="mb-2 block text-sm font-medium text-stone-700">
             Nom <span class="text-amber-500">*</span>
           </label>
@@ -56,7 +56,7 @@
 
       {{/* Email & Téléphone */}}
       <div class="grid gap-6 md:grid-cols-2">
-        <div>
+        <div class="min-w-0">
           <label for="Email" class="mb-2 block text-sm font-medium text-stone-700">
             Email <span class="text-amber-500">*</span>
           </label>
@@ -71,7 +71,7 @@
           >
         </div>
 
-        <div>
+        <div class="min-w-0">
           <label for="Phone" class="mb-2 block text-sm font-medium text-stone-700">
             Téléphone
           </label>
@@ -88,7 +88,7 @@
 
       {{/* Date & Type */}}
       <div class="grid gap-6 md:grid-cols-2">
-        <div>
+        <div class="min-w-0">
           <label for="date" class="mb-2 block text-sm font-medium text-stone-700">
             Date souhaitée <span class="text-amber-500">*</span>
           </label>
@@ -101,7 +101,7 @@
           >
         </div>
 
-        <div>
+        <div class="min-w-0">
           <label for="reason" class="mb-2 block text-sm font-medium text-stone-700">
             Type d'évènement
           </label>


### PR DESCRIPTION
Les enfants des grilles CSS ont min-width: auto par défaut, ce qui
empêche les inputs w-full de rétrécir sous leur taille intrinsèque.
Ajout de min-w-0 sur chaque cellule de grille pour que les champs
respectent les limites de leur colonne et ne se chevauchent plus.

https://claude.ai/code/session_01WPw6Ku1oJFgyRrdqB3BsVK